### PR TITLE
[CN-626] Support deleting upload tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Backup command starts an HTTP server for Backup related tasks. Learn more about 
 
 - `POST /upload`: Agent starts an asynchronous backup process. It uploads the latest Hazelcast backup into specified bucket, arhiving the folder in the process. Returns an id of the backup process.
 - `GET /upload/{id}`: Returns the status of the backup.
-- `DELETE /upload/{id}`: Cancels the backup process.
+- `POST /upload/{id}/cancel`: Cancels the backup process.
+- `DELETE /upload/{id}`: Deletes the backup process status.
 - `GET /health`: Returns success if application is running.
 
 ## License

--- a/sidecar/router.go
+++ b/sidecar/router.go
@@ -217,6 +217,30 @@ func (s *Service) cancelHandler(w http.ResponseWriter, r *http.Request) {
 	t.cancel()
 }
 
+func (s *Service) deleteHandler(w http.ResponseWriter, r *http.Request) {
+	log.Println(r.Method, r.URL)
+
+	vars := mux.Vars(r)
+
+	ID, err := uuid.Parse(vars["id"])
+	if err != nil {
+		serverutil.HttpError(w, http.StatusBadRequest)
+		return
+	}
+
+	s.Mu.RLock()
+	if _, ok := s.Tasks[ID]; !ok {
+		s.Mu.RUnlock()
+		log.Println("DELETE", ID, "task not found")
+		serverutil.HttpError(w, http.StatusNotFound)
+		return
+	}
+	delete(s.Tasks, ID)
+	s.Mu.RUnlock()
+
+	log.Println("DELETE", ID, "Deleted task")
+}
+
 type DialRequest struct {
 	Endpoints string `json:"endpoints"`
 }

--- a/sidecar/server.go
+++ b/sidecar/server.go
@@ -35,7 +35,8 @@ func startServer(s *Cmd) error {
 		router.HandleFunc("/backup", backupService.listBackupsHandler).Methods("GET")
 		router.HandleFunc("/upload", backupService.uploadHandler).Methods("POST")
 		router.HandleFunc("/upload/{id}", backupService.statusHandler).Methods("GET")
-		router.HandleFunc("/upload/{id}", backupService.cancelHandler).Methods("DELETE")
+		router.HandleFunc("/upload/{id}/cancel", backupService.cancelHandler).Methods("POST")
+		router.HandleFunc("/upload/{id}", backupService.deleteHandler).Methods("DELETE")
 		router.HandleFunc("/dial", dialHandler).Methods("POST")
 		router.HandleFunc("/health", healthcheckHandler)
 		server := &http.Server{

--- a/sidecar/server_test.go
+++ b/sidecar/server_test.go
@@ -288,7 +288,7 @@ func TestCancelHandler(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set up
 			us := &Service{Tasks: tt.taskMap}
-			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("http://request/upload/%s", tt.reqId), nil)
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("http://request/upload/%s/cancel", tt.reqId), nil)
 			w := httptest.NewRecorder()
 			vars := map[string]string{
 				"id": tt.reqId,
@@ -296,10 +296,61 @@ func TestCancelHandler(t *testing.T) {
 			req = mux.SetURLVars(req, vars)
 
 			// Test
-			us.statusHandler(w, req)
+			us.cancelHandler(w, req)
 			res := w.Result()
 			st := res.StatusCode
 			assert.Equal(t, tt.wantStatusCode, st, "Status is: ", st)
+		})
+	}
+}
+
+func TestDeleteHandler(t *testing.T) {
+	tests := []struct {
+		name  string
+		tasks map[uuid.UUID]*task
+		reqID string
+		want  int
+	}{
+		{
+			"in-progress task",
+			map[uuid.UUID]*task{stringToUUID(""): inProgressTask(UploadReq{})},
+			stringToUUID("").String(),
+			http.StatusOK,
+		},
+		{
+			"successful task",
+			map[uuid.UUID]*task{stringToUUID(""): successfulTask(UploadReq{})},
+			stringToUUID("").String(),
+			http.StatusOK,
+		},
+		{
+			"task is not in map",
+			map[uuid.UUID]*task{},
+			stringToUUID("").String(),
+			http.StatusNotFound,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up
+			service := &Service{Tasks: tt.tasks}
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("http://request/upload/%s", tt.reqID), nil)
+			req = mux.SetURLVars(req, map[string]string{
+				"id": tt.reqID,
+			})
+
+			// Test
+			w := httptest.NewRecorder()
+			service.deleteHandler(w, req)
+			statusCode := w.Result().StatusCode
+
+			assert.Equal(t, tt.want, statusCode, "Status is: ", statusCode)
+
+			w = httptest.NewRecorder()
+			service.statusHandler(w, req)
+			statusCode = w.Result().StatusCode
+
+			assert.Equal(t, http.StatusNotFound, statusCode, "Status is: ", statusCode)
 		})
 	}
 }


### PR DESCRIPTION
Operator will now use this API to explicitly delete upload tasks after they're done.