### PR TITLE
[CN-1134] Check restore dir before loading backup

### DIFF
--- a/init/restore/bucket_to_pvc_cmd.go
+++ b/init/restore/bucket_to_pvc_cmd.go
@@ -50,15 +50,13 @@ func (r *BucketToPVCCmd) Execute(ctx context.Context, _ *flag.FlagSet, _ ...inte
 		return subcommands.ExitFailure
 	}
 
-	// Check if the restore dir already exists.
-	// This case happens when trying to restore into a PersistentVolume that already contains a restore (hot-restart) dir. 
-	dirs, err := fileutil.FolderUUIDs(r.Destination)
+	restoreDirExists, err := isRestoreDirExisting(r.Destination)
 	if err != nil {
-		bucketToPVCLog.Error("an error occurred while checking if restore dir" + err.Error())
+		bucketToPVCLog.Error("an error occurred while checking existing restore dir" + err.Error())
 		return subcommands.ExitFailure
 	}
-	if len(dirs) > 0 {
-		bucketToPVCLog.Error("restore dir already exists: " + dirs[0].Name())
+	if restoreDirExists {
+		bucketToPVCLog.Error("restore dir already exists")
 		return subcommands.ExitSuccess
 	}
 

--- a/init/restore/bucket_to_pvc_cmd.go
+++ b/init/restore/bucket_to_pvc_cmd.go
@@ -50,6 +50,18 @@ func (r *BucketToPVCCmd) Execute(ctx context.Context, _ *flag.FlagSet, _ ...inte
 		return subcommands.ExitFailure
 	}
 
+	// Check if the restore dir already exists.
+	// This case happens when trying to restore into a PersistentVolume that already contains a restore (hot-restart) dir. 
+	dirs, err := fileutil.FolderUUIDs(r.Destination)
+	if err != nil {
+		bucketToPVCLog.Error("an error occurred while checking if restore dir" + err.Error())
+		return subcommands.ExitFailure
+	}
+	if len(dirs) > 0 {
+		bucketToPVCLog.Error("restore dir already exists: " + dirs[0].Name())
+		return subcommands.ExitSuccess
+	}
+
 	if !hostnameRE.MatchString(r.Hostname) {
 		bucketToPVCLog.Error("invalid hostname, need to conform to statefulset naming scheme")
 		return subcommands.ExitFailure

--- a/init/restore/common.go
+++ b/init/restore/common.go
@@ -17,6 +17,7 @@ import (
 
 	"gocloud.dev/blob"
 
+	"github.com/hazelcast/platform-operator-agent/internal/fileutil"
 	"github.com/hazelcast/platform-operator-agent/sidecar"
 )
 
@@ -173,4 +174,14 @@ func createArchiveFile(dir, baseDir, outPath string) error {
 	defer outFile.Close()
 
 	return sidecar.CreateArchive(outFile, dir, baseDir)
+}
+
+// isRestoreDirExisting checks if the restore dir already exists.
+// It happens when trying to restore a backup into a PersistentVolume that already contains a restore (hot-restart) dir.
+func isRestoreDirExisting(path string) (bool, error) {
+	dirs, err := fileutil.FolderUUIDs(path)
+	if err != nil {
+		return false, err
+	}
+	return len(dirs) > 0, nil
 }

--- a/init/restore/local_in_pvc_cmd.go
+++ b/init/restore/local_in_pvc_cmd.go
@@ -66,15 +66,13 @@ func (r *LocalInPVCCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...interfa
 		return subcommands.ExitFailure
 	}
 
-	// Check if the restore dir already exists.
-	// This case happens when trying to restore into a PersistentVolume that already contains a restore (hot-restart) dir. 
-	dirs, err := fileutil.FolderUUIDs(r.BackupBaseDir)
+	restoreDirExists, err := isRestoreDirExisting(r.BackupBaseDir)
 	if err != nil {
-		bucketToPVCLog.Error("an error occurred while checking if restore dir" + err.Error())
+		bucketToPVCLog.Error("an error occurred while checking existing restore dir" + err.Error())
 		return subcommands.ExitFailure
 	}
-	if len(dirs) > 0 {
-		bucketToPVCLog.Error("restore dir already exists: " + dirs[0].Name())
+	if restoreDirExists {
+		bucketToPVCLog.Error("restore dir already exists")
 		return subcommands.ExitSuccess
 	}
 


### PR DESCRIPTION
The init container `restore-agent` won't override the existing restore (hot-restart) dir. It first checks if there is an existing restore dir before loading the data from hot-backup.

```
{"level":"info","ts":1708516449.4284656,"logger":"restore_from_bucket_to_pvc","caller":"restore/bucket_to_pvc_cmd.go:45","msg":"starting restore agent..."}
{"level":"error","ts":1708516449.42913,"logger":"restore_from_bucket_to_pvc","caller":"restore/bucket_to_pvc_cmd.go:61","msg":"restore dir already exists: e684d972-5685-42f5-b1df-b6dbaa5ad880","stacktrace":"github.com/hazelcast/platform-operator-agent/init/restore.(*BucketToPVCCmd).Execute\n\t/app/init/restore/bucket_to_pvc_cmd.go:61\ngithub.com/google/subcommands.(*Commander).Execute\n\t/go/pkg/mod/github.com/google/subcommands@v1.0.1/subcommands.go:142\ngithub.com/google/subcommands.Execute\n\t/go/pkg/mod/github.com/google/subcommands@v1.0.1/subcommands.go:420\nmain.main\n\t/app/main.go:30\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:250"}
```

It happens when trying to restore into a PersistentVolume that already contains a restore (hot-restart) dir.

The init-container logs the reason why it didn't reload data from the hot-backup the but It doesn't fail.