### PR TITLE
[CN-1134] Revert restore changes

### DIFF
--- a/init/restore/bucket_to_pvc_cmd.go
+++ b/init/restore/bucket_to_pvc_cmd.go
@@ -52,7 +52,7 @@ func (r *BucketToPVCCmd) Execute(ctx context.Context, _ *flag.FlagSet, _ ...inte
 
 	restoreDirExists, err := isRestoreDirExisting(r.Destination)
 	if err != nil {
-		bucketToPVCLog.Error("an error occurred while checking if restore dir exists" + err.Error())
+		bucketToPVCLog.Error("an error occurred while checking existing restore dir" + err.Error())
 		return subcommands.ExitFailure
 	}
 	if restoreDirExists {

--- a/init/restore/bucket_to_pvc_cmd.go
+++ b/init/restore/bucket_to_pvc_cmd.go
@@ -50,16 +50,6 @@ func (r *BucketToPVCCmd) Execute(ctx context.Context, _ *flag.FlagSet, _ ...inte
 		return subcommands.ExitFailure
 	}
 
-	restoreDirExists, err := isRestoreDirExisting(r.Destination)
-	if err != nil {
-		bucketToPVCLog.Error("an error occurred while checking existing restore dir" + err.Error())
-		return subcommands.ExitFailure
-	}
-	if restoreDirExists {
-		bucketToPVCLog.Error("restore dir already exists")
-		return subcommands.ExitSuccess
-	}
-
 	if !hostnameRE.MatchString(r.Hostname) {
 		bucketToPVCLog.Error("invalid hostname, need to conform to statefulset naming scheme")
 		return subcommands.ExitFailure

--- a/init/restore/common.go
+++ b/init/restore/common.go
@@ -17,7 +17,6 @@ import (
 
 	"gocloud.dev/blob"
 
-	"github.com/hazelcast/platform-operator-agent/internal/fileutil"
 	"github.com/hazelcast/platform-operator-agent/sidecar"
 )
 
@@ -174,14 +173,4 @@ func createArchiveFile(dir, baseDir, outPath string) error {
 	defer outFile.Close()
 
 	return sidecar.CreateArchive(outFile, dir, baseDir)
-}
-
-// isRestoreDirExisting checks if the restore dir already exists.
-// It happens when trying to restore a backup into a PersistentVolume that already contains a restore (hot-restart) dir.
-func isRestoreDirExisting(path string) (bool, error) {
-	dirs, err := fileutil.FolderUUIDs(path)
-	if err != nil {
-		return false, err
-	}
-	return len(dirs) > 0, nil
 }

--- a/init/restore/local_in_pvc_cmd.go
+++ b/init/restore/local_in_pvc_cmd.go
@@ -66,16 +66,6 @@ func (r *LocalInPVCCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...interfa
 		return subcommands.ExitFailure
 	}
 
-	restoreDirExists, err := isRestoreDirExisting(r.BackupBaseDir)
-	if err != nil {
-		bucketToPVCLog.Error("an error occurred while checking existing restore dir" + err.Error())
-		return subcommands.ExitFailure
-	}
-	if restoreDirExists {
-		bucketToPVCLog.Error("restore dir already exists")
-		return subcommands.ExitSuccess
-	}
-
 	if !hostnameRE.MatchString(r.Hostname) {
 		localInPVCLog.Error("invalid hostname, need to conform to statefulset naming scheme")
 		return subcommands.ExitFailure
@@ -115,7 +105,7 @@ func (r *LocalInPVCCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...interfa
 	return subcommands.ExitSuccess
 }
 
-func copyBackupPVC(backupDir, dstDir string) error {
+func copyBackupPVC(backupDir, destDir string) error {
 	backupUUIDs, err := fileutil.FolderUUIDs(backupDir)
 	if err != nil {
 		return err
@@ -125,21 +115,21 @@ func copyBackupPVC(backupDir, dstDir string) error {
 		return fmt.Errorf("incorrect number of backups %d in backup sequence folder", len(backupUUIDs))
 	}
 
-	dstBackupUUIDS, err := fileutil.FolderUUIDs(dstDir)
+	destBackupUUIDS, err := fileutil.FolderUUIDs(destDir)
 	if err != nil {
 		return err
 	}
 
 	// Remove the hot-restart folder at the destination
-	for _, uuid := range dstBackupUUIDS {
-		err = os.RemoveAll(path.Join(dstDir, uuid.Name()))
+	for _, uuid := range destBackupUUIDS {
+		err = os.RemoveAll(path.Join(destDir, uuid.Name()))
 		if err != nil {
 			return err
 		}
 	}
 
 	bk := backupUUIDs[0].Name()
-	return copyDir(path.Join(backupDir, bk), path.Join(dstDir, bk))
+	return copyDir(path.Join(backupDir, bk), path.Join(destDir, bk))
 }
 
 func lockFileName(restoreId string, memberId int) string {

--- a/init/restore/local_in_pvc_cmd.go
+++ b/init/restore/local_in_pvc_cmd.go
@@ -66,6 +66,16 @@ func (r *LocalInPVCCmd) Execute(_ context.Context, _ *flag.FlagSet, _ ...interfa
 		return subcommands.ExitFailure
 	}
 
+	restoreDirExists, err := isRestoreDirExisting(r.BackupBaseDir)
+	if err != nil {
+		bucketToPVCLog.Error("an error occurred while checking existing restore dir" + err.Error())
+		return subcommands.ExitFailure
+	}
+	if restoreDirExists {
+		bucketToPVCLog.Error("restore dir already exists")
+		return subcommands.ExitSuccess
+	}
+
 	if !hostnameRE.MatchString(r.Hostname) {
 		localInPVCLog.Error("invalid hostname, need to conform to statefulset naming scheme")
 		return subcommands.ExitFailure


### PR DESCRIPTION
We have determined that the `restore` should be more privileged, allowing it to overwrite hot-backup data. As a result, the modifications made in #63 and #65 have been rolled back, and the upcoming agent version release will exclude these changes.