### PR TITLE
Make cp flags compatible with unix cp command

### DIFF
--- a/sidecar/server_test.go
+++ b/sidecar/server_test.go
@@ -480,7 +480,7 @@ func TestUploadBackup(t *testing.T) {
 
 			// copy the files under backupDir for checking later
 			backupDirCopy := path.Join(tmpdir, "backupDirCopy")
-			cmd := exec.Command("cp", "--recursive", backupDir, backupDirCopy)
+			cmd := exec.Command("cp", "-R", backupDir, backupDirCopy)
 			err = cmd.Run()
 			require.Nil(t, err)
 


### PR DESCRIPTION
The test case fails in macos since the flag `--recurive` is not comaptible with unix cp command.
I was running it with gnu wrappers in my setup. However `-R` flag is enough to make it compatible. 